### PR TITLE
Glow Mask Fix, Asymmetric Equips Support

### DIFF
--- a/CombinationsPlayer.cs
+++ b/CombinationsPlayer.cs
@@ -21,6 +21,8 @@ using System.Collections.Generic;
 using Combinations.Items.WildernessGuide;
 using Combinations.Items.UnholyAbomination;
 using Combinations.Items.CloudOutOfBottle;
+using ReLogic.Content;
+using Microsoft.Xna.Framework.Graphics;
 
 namespace Combinations
 {
@@ -30,7 +32,14 @@ namespace Combinations
 
         public int NebulaCharmCharge = 0;
 
+        public Asset<Texture2D> handsOnGlowMask;
+
         private static int[] RecoveryBuffAccessories => new int[] { OvergrownTreads.ItemType(), JungleBoots.ItemType() };
+
+        public override void ResetEffects()
+        {
+            handsOnGlowMask = null;
+        }
 
         public override void ModifyDrawInfo(ref PlayerDrawSet drawInfo)
         {

--- a/HandsOnAccessoryGlowDrawLayer.cs
+++ b/HandsOnAccessoryGlowDrawLayer.cs
@@ -1,8 +1,6 @@
-﻿using Combinations.Items.NebulaCharm;
-using Combinations.Items.SolarCharm;
-using Combinations.Items.StardustCharm;
-using Combinations.Items.VortexCharm;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.ModLoader;
@@ -13,55 +11,11 @@ namespace Combinations
     {
         protected override void Draw(ref PlayerDrawSet drawInfo)
         {
-            if(Helpers.IsPlayerAccessoryVisible<SolarCharm>(drawInfo.drawPlayer))
+            Asset<Texture2D> handsOnGlowMask = drawInfo.drawPlayer.GetModPlayer<CombinationsPlayer>().handsOnGlowMask;
+            if (handsOnGlowMask != null)
             {
                 DrawData item = new DrawData(
-                    SolarCharm.GlowMaskTexture.Value,
-                    new Vector2((int)(drawInfo.Position.X - Main.screenPosition.X - (float)(drawInfo.drawPlayer.bodyFrame.Width / 2) + (float)(drawInfo.drawPlayer.width / 2)), (int)(drawInfo.Position.Y - Main.screenPosition.Y + (float)drawInfo.drawPlayer.height - (float)drawInfo.drawPlayer.bodyFrame.Height + 4f)) + drawInfo.drawPlayer.bodyPosition + new Vector2(drawInfo.drawPlayer.bodyFrame.Width / 2, drawInfo.drawPlayer.bodyFrame.Height / 2),
-                    drawInfo.drawPlayer.bodyFrame,
-                    Color.White,
-                    drawInfo.drawPlayer.bodyRotation,
-                    drawInfo.bodyVect,
-                    1f,
-                    drawInfo.playerEffect,
-                    0);
-                item.shader = drawInfo.cHandOn;
-                drawInfo.DrawDataCache.Add(item);
-            }
-            if (Helpers.IsPlayerAccessoryVisible<NebulaCharm>(drawInfo.drawPlayer))
-            {
-                DrawData item = new DrawData(
-                    NebulaCharm.GlowMaskTexture.Value,
-                    new Vector2((int)(drawInfo.Position.X - Main.screenPosition.X - (float)(drawInfo.drawPlayer.bodyFrame.Width / 2) + (float)(drawInfo.drawPlayer.width / 2)), (int)(drawInfo.Position.Y - Main.screenPosition.Y + (float)drawInfo.drawPlayer.height - (float)drawInfo.drawPlayer.bodyFrame.Height + 4f)) + drawInfo.drawPlayer.bodyPosition + new Vector2(drawInfo.drawPlayer.bodyFrame.Width / 2, drawInfo.drawPlayer.bodyFrame.Height / 2),
-                    drawInfo.drawPlayer.bodyFrame,
-                    Color.White,
-                    drawInfo.drawPlayer.bodyRotation,
-                    drawInfo.bodyVect,
-                    1f,
-                    drawInfo.playerEffect,
-                    0);
-                item.shader = drawInfo.cHandOn;
-                drawInfo.DrawDataCache.Add(item);
-            }
-            if (Helpers.IsPlayerAccessoryVisible<StardustCharm>(drawInfo.drawPlayer))
-            {
-                DrawData item = new DrawData(
-                    StardustCharm.GlowMaskTexture.Value,
-                    new Vector2((int)(drawInfo.Position.X - Main.screenPosition.X - (float)(drawInfo.drawPlayer.bodyFrame.Width / 2) + (float)(drawInfo.drawPlayer.width / 2)), (int)(drawInfo.Position.Y - Main.screenPosition.Y + (float)drawInfo.drawPlayer.height - (float)drawInfo.drawPlayer.bodyFrame.Height + 4f)) + drawInfo.drawPlayer.bodyPosition + new Vector2(drawInfo.drawPlayer.bodyFrame.Width / 2, drawInfo.drawPlayer.bodyFrame.Height / 2),
-                    drawInfo.drawPlayer.bodyFrame,
-                    Color.White,
-                    drawInfo.drawPlayer.bodyRotation,
-                    drawInfo.bodyVect,
-                    1f,
-                    drawInfo.playerEffect,
-                    0);
-                item.shader = drawInfo.cHandOn;
-                drawInfo.DrawDataCache.Add(item);
-            }
-            if (Helpers.IsPlayerAccessoryVisible<VortexCharm>(drawInfo.drawPlayer))
-            {
-                DrawData item = new DrawData(
-                    VortexCharm.GlowMaskTexture.Value,
+                    handsOnGlowMask.Value,
                     new Vector2((int)(drawInfo.Position.X - Main.screenPosition.X - (float)(drawInfo.drawPlayer.bodyFrame.Width / 2) + (float)(drawInfo.drawPlayer.width / 2)), (int)(drawInfo.Position.Y - Main.screenPosition.Y + (float)drawInfo.drawPlayer.height - (float)drawInfo.drawPlayer.bodyFrame.Height + 4f)) + drawInfo.drawPlayer.bodyPosition + new Vector2(drawInfo.drawPlayer.bodyFrame.Width / 2, drawInfo.drawPlayer.bodyFrame.Height / 2),
                     drawInfo.drawPlayer.bodyFrame,
                     Color.White,

--- a/Helpers.cs
+++ b/Helpers.cs
@@ -14,6 +14,7 @@ namespace Combinations
             _Calamity_Mod_Player_Type_Is_Scanned = false;
             _Calamity_Mod_Player_Type = null;
             _Calamity_Mod_Player_Method = null;
+            _asymmetricEquipsMod = null;
         }
 
         public static bool HasPlayerItemInInventory(Player player, int type)
@@ -249,6 +250,41 @@ namespace Combinations
                 _Calamity_Mod_Player_Method = method.MakeGenericMethod(calamity_player_type);
             }
             return _Calamity_Mod_Player_Method;
+        }
+
+        private static Mod _asymmetricEquipsMod;
+
+        public static void AddAsymmetricEquipHidden(ModItem item, EquipType type)
+        {
+            if (_asymmetricEquipsMod == null && !ModLoader.TryGetMod("AsymmetricEquips", out _asymmetricEquipsMod))
+            {
+                return;
+            }
+
+            int equipSlot = type switch
+            {
+                EquipType.Head => item.Item.headSlot,
+                EquipType.Body => item.Item.bodySlot,
+                EquipType.Legs => item.Item.legSlot,
+                EquipType.HandsOn => item.Item.handOnSlot,
+                EquipType.HandsOff => item.Item.handOffSlot,
+                EquipType.Back => item.Item.backSlot,
+                EquipType.Front => item.Item.frontSlot,
+                EquipType.Shoes => item.Item.shoeSlot,
+                EquipType.Waist => item.Item.waistSlot,
+                EquipType.Wings => item.Item.wingSlot,
+                EquipType.Shield => item.Item.shieldSlot,
+                EquipType.Neck => item.Item.neckSlot,
+                EquipType.Face => item.Item.faceSlot,
+                EquipType.Balloon => item.Item.balloonSlot,
+                EquipType.Beard => item.Item.beardSlot,
+                _ => throw new NotImplementedException(),
+            };
+
+            if (equipSlot != -1)
+            {
+                _asymmetricEquipsMod.Call("AddEquip", type, equipSlot);
+            }
         }
     }
 }

--- a/Items/BandOfToughness/BandOfToughness.cs
+++ b/Items/BandOfToughness/BandOfToughness.cs
@@ -40,6 +40,7 @@ does not slow or stop when the player is moving or being attacked.
             {
                 base_regen_value = regenerationBand.lifeRegen;
             }
+            Helpers.AddAsymmetricEquipHidden(this, EquipType.HandsOn);
         }
 
         public override void SetDefaults()

--- a/Items/CharmOfEndurance/CharmOfEndurance.cs
+++ b/Items/CharmOfEndurance/CharmOfEndurance.cs
@@ -14,6 +14,7 @@ namespace Combinations.Items.CharmOfEndurance
                 "Reduces the cooldown of healing potions by 25%");
             DisplayName.SetDefault("Charm of Endurance");
             CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
+            Helpers.AddAsymmetricEquipHidden(this, EquipType.HandsOn);
         }
 
         public override void SetDefaults()

--- a/Items/CharmOfRangers/CharmOfRangers.cs
+++ b/Items/CharmOfRangers/CharmOfRangers.cs
@@ -16,6 +16,7 @@ namespace Combinations.Items.CharmOfRangers
                 "5% ranged critical strike chance");
             DisplayName.SetDefault("Charm of Rangers");
             CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
+            Helpers.AddAsymmetricEquipHidden(this, EquipType.HandsOn);
         }
 
         public override void SetDefaults()

--- a/Items/CharmOfSummoning/CharmOfSummoning.cs
+++ b/Items/CharmOfSummoning/CharmOfSummoning.cs
@@ -16,6 +16,7 @@ namespace Combinations.Items.CharmOfSummoning
                 "8% increased whip speed");
             DisplayName.SetDefault("Charm of Summoning");
             CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
+            Helpers.AddAsymmetricEquipHidden(this, EquipType.HandsOn);
         }
 
         public override void SetDefaults()

--- a/Items/CharmOfThrowing/CharmOfThrowing.cs
+++ b/Items/CharmOfThrowing/CharmOfThrowing.cs
@@ -18,6 +18,7 @@ namespace Combinations.Items.CharmOfThrowing
                 "'The path ahead is unclear'");
             DisplayName.SetDefault("Charm of Throwing");
             CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
+            Helpers.AddAsymmetricEquipHidden(this, EquipType.HandsOn);
         }
 
         public override void SetDefaults()

--- a/Items/CharmOfWarriors/CharmOfWarriors.cs
+++ b/Items/CharmOfWarriors/CharmOfWarriors.cs
@@ -15,6 +15,7 @@ namespace Combinations.Items.CharmOfWarriors
                 "5% increased melee damage");
             DisplayName.SetDefault("Charm of Warriors");
             CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
+            Helpers.AddAsymmetricEquipHidden(this, EquipType.HandsOn);
         }
 
         public override void SetDefaults()

--- a/Items/CharmOfWizards/CharmOfWizards.cs
+++ b/Items/CharmOfWizards/CharmOfWizards.cs
@@ -16,6 +16,7 @@ namespace Combinations.Items.CharmOfWizards
                 "5% increased magic damage");
             DisplayName.SetDefault("Charm of Wizards");
             CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
+            Helpers.AddAsymmetricEquipHidden(this, EquipType.HandsOn);
         }
 
         public override void SetDefaults()

--- a/Items/MasterThrowingCharm/MasterThrowingCharm.cs
+++ b/Items/MasterThrowingCharm/MasterThrowingCharm.cs
@@ -17,6 +17,7 @@ namespace Combinations.Items.MasterThrowingCharm
                 "20% increased throwing velocity\n" +
                 "Throws two projectiles at a time");
             CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
+            Helpers.AddAsymmetricEquipHidden(this, EquipType.HandsOn);
         }
 
         public override void SetDefaults()

--- a/Items/NebulaCharm/NebulaCharm.cs
+++ b/Items/NebulaCharm/NebulaCharm.cs
@@ -24,6 +24,7 @@ namespace Combinations.Items.NebulaCharm
             {
                 GlowMaskTexture = ModContent.Request<Texture2D>("Combinations/Items/NebulaCharm/NebulaCharm_HandsOn_Glow");
             }
+            Helpers.AddAsymmetricEquipHidden(this, EquipType.HandsOn);
         }
 
         public override void Unload()
@@ -76,5 +77,10 @@ namespace Combinations.Items.NebulaCharm
                 StardustCharm.StardustCharm.ItemType(),
                 MasterThrowingCharm.MasterThrowingCharm.ItemType()
             };
+
+        public override void EquipFrameEffects(Player player, EquipType type)
+        {
+            player.GetModPlayer<CombinationsPlayer>().handsOnGlowMask = GlowMaskTexture;
+        }
     }
 }

--- a/Items/SolarCharm/SolarCharm.cs
+++ b/Items/SolarCharm/SolarCharm.cs
@@ -24,6 +24,7 @@ namespace Combinations.Items.SolarCharm
             {
                 GlowMaskTexture = ModContent.Request<Texture2D>("Combinations/Items/SolarCharm/SolarCharm_HandsOn_Glow");
             }
+            Helpers.AddAsymmetricEquipHidden(this, EquipType.HandsOn);
         }
 
         public override void Unload()
@@ -75,5 +76,10 @@ namespace Combinations.Items.SolarCharm
                 NebulaCharm.NebulaCharm.ItemType(),
                 MasterThrowingCharm.MasterThrowingCharm.ItemType()
             };
+
+        public override void EquipFrameEffects(Player player, EquipType type)
+        {
+            player.GetModPlayer<CombinationsPlayer>().handsOnGlowMask = GlowMaskTexture;
+        }
     }
 }

--- a/Items/StardustCharm/StardustCharm.cs
+++ b/Items/StardustCharm/StardustCharm.cs
@@ -24,6 +24,7 @@ namespace Combinations.Items.StardustCharm
             {
                 GlowMaskTexture = ModContent.Request<Texture2D>("Combinations/Items/StardustCharm/StardustCharm_HandsOn_Glow");
             }
+            Helpers.AddAsymmetricEquipHidden(this, EquipType.HandsOn);
         }
 
         public override void Unload()
@@ -77,5 +78,10 @@ namespace Combinations.Items.StardustCharm
                 NebulaCharm.NebulaCharm.ItemType(),
                 MasterThrowingCharm.MasterThrowingCharm.ItemType()
             };
+
+        public override void EquipFrameEffects(Player player, EquipType type)
+        {
+            player.GetModPlayer<CombinationsPlayer>().handsOnGlowMask = GlowMaskTexture;
+        }
     }
 }

--- a/Items/VortexCharm/VortexCharm.cs
+++ b/Items/VortexCharm/VortexCharm.cs
@@ -24,6 +24,7 @@ namespace Combinations.Items.VortexCharm
             {
                 GlowMaskTexture = ModContent.Request<Texture2D>("Combinations/Items/VortexCharm/VortexCharm_HandsOn_Glow");
             }
+            Helpers.AddAsymmetricEquipHidden(this, EquipType.HandsOn);
         }
 
         public override void Unload()
@@ -76,5 +77,10 @@ namespace Combinations.Items.VortexCharm
                 NebulaCharm.NebulaCharm.ItemType(),
                 MasterThrowingCharm.MasterThrowingCharm.ItemType()
             };
+
+        public override void EquipFrameEffects(Player player, EquipType type)
+        {
+            player.GetModPlayer<CombinationsPlayer>().handsOnGlowMask = GlowMaskTexture;
+        }
     }
 }


### PR DESCRIPTION
* Fixed the Hands On glow mask of the Solar/Vortex/Nebula/Stardust Charms appearing even if the charm was not visible. (Ex: Wearing another HandsOn equip over the Charm).
* Added basic support for the mod "Asymmetric Equips": https://steamcommunity.com/sharedfiles/filedetails/?id=2878558240